### PR TITLE
Correcting version of ServiceStack.Text referenced from nuget

### DIFF
--- a/SWF.Extensions/SWF.Extensions.Core/packages.config
+++ b/SWF.Extensions/SWF.Extensions.Core/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AWSSDK" version="2.2.2.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="3.9.71" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="4.0.24" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The fsproj file is expecting version 4.0.24, however nuget is only grabbing 3.9.71, so anyone checking out the code is unable to compile it
